### PR TITLE
Add Notes, Files, and Activity properties to Notion leads sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,3 +280,13 @@ CI uses Node 24, pnpm 10.26.1, `--frozen-lockfile`, with pnpm store caching.
 - Scheduled database backup CI (`/.github/workflows/backup.yml`) was failing: `DATABASE_URL` secret was not set (secrets must be added manually in repo Settings → Secrets → Actions), and `postgresql-client` apt package installs PG16 which `pg_dump` rejects against a Neon PG17 server
 - Fixed by installing `postgresql-client-17` explicitly and adding a Verify secrets step for a clear error message when `DATABASE_URL` is missing
 - Removed redundant `PGPASSWORD`/`DB_PASSWORD` secret — Neon connection URL embeds credentials
+
+## Pending Setup Tasks
+
+### Notion Integration (TODO)
+- Create a **public** Notion integration at [notion.so/my-integrations](https://www.notion.so/my-integrations)
+- Set OAuth redirect URI to: `https://anthology-fiesta.onrender.com/api/integrations/notion/callback`
+- Add `NOTION_CLIENT_ID` and `NOTION_CLIENT_SECRET` as environment variables on Render
+- After Render redeploys, connect Notion from the Fiesta integrations screen
+- Then configure database IDs in Fiesta settings: `notion_leads_db`, `notion_contacts_db`, `notion_activities_db`
+- Notion Leads database properties must use exact casing: `Name`, `Email`, `Status`, `Source`, `Is Beta`, `Notes`, `Files`, `Activity`

--- a/artifacts/api-server/src/lib/integrations/notes/notion.ts
+++ b/artifacts/api-server/src/lib/integrations/notes/notion.ts
@@ -30,29 +30,46 @@ export class NotionProvider implements NotesProvider {
     return res.json();
   }
 
+  private buildLeadProperties(lead: any): Record<string, unknown> {
+    const props: Record<string, unknown> = {
+      Name: { title: [{ text: { content: lead.name } }] },
+      Email: { email: lead.email },
+      Status: { select: { name: lead.status } },
+      Source: { select: { name: lead.source } },
+      "Is Beta": { checkbox: lead.isBeta },
+    };
+
+    if (lead.notes) {
+      props.Notes = { rich_text: [{ text: { content: lead.notes.slice(0, 2000) } }] };
+    }
+
+    if (lead._activitySummary) {
+      props.Activity = { rich_text: [{ text: { content: lead._activitySummary.slice(0, 2000) } }] };
+    }
+
+    if (lead._fileUrls?.length) {
+      props.Files = {
+        files: lead._fileUrls.map((f: { name: string; url: string }) => ({
+          type: "external",
+          name: f.name,
+          external: { url: f.url },
+        })),
+      };
+    }
+
+    return props;
+  }
+
   async syncLead(lead: any, databaseId: string): Promise<string | null> {
     try {
+      const properties = this.buildLeadProperties(lead);
       if (lead.notionPageId) {
-        await this.notionRequest(`/pages/${lead.notionPageId}`, "PATCH", {
-          properties: {
-            Name: { title: [{ text: { content: lead.name } }] },
-            Email: { email: lead.email },
-            Status: { select: { name: lead.status } },
-            Source: { select: { name: lead.source } },
-            "Is Beta": { checkbox: lead.isBeta },
-          },
-        });
+        await this.notionRequest(`/pages/${lead.notionPageId}`, "PATCH", { properties });
         return lead.notionPageId;
       } else {
         const res = await this.notionRequest("/pages", "POST", {
           parent: { database_id: databaseId },
-          properties: {
-            Name: { title: [{ text: { content: lead.name } }] },
-            Email: { email: lead.email },
-            Status: { select: { name: lead.status } },
-            Source: { select: { name: lead.source } },
-            "Is Beta": { checkbox: lead.isBeta },
-          },
+          properties,
         });
         return res?.id || null;
       }

--- a/artifacts/api-server/src/lib/notionPullWorker.ts
+++ b/artifacts/api-server/src/lib/notionPullWorker.ts
@@ -110,6 +110,7 @@ async function pullLeadsFromNotion(userId: string, databaseId: string, accessTok
       const status = extractNotionSelect(props, "Status") || "new";
       const source = extractNotionSelect(props, "Source") || "notion";
       const isBeta = extractNotionCheckbox(props, "Is Beta");
+      const notes = extractNotionRichText(props, "Notes");
 
       // Find existing record by notionPageId
       const [existing] = await db
@@ -123,7 +124,7 @@ async function pullLeadsFromNotion(userId: string, databaseId: string, accessTok
         const crmUpdated = existing.updatedAt ? new Date(existing.updatedAt) : new Date(0);
         if (notionEdited > crmUpdated) {
           await db.update(leadsTable)
-            .set({ name, email: email ?? undefined, status, source, isBeta, updatedAt: new Date() })
+            .set({ name, email: email ?? undefined, status, source, isBeta, notes, updatedAt: new Date() })
             .where(and(eq(leadsTable.id, existing.id), eq(leadsTable.userId, userId)));
         }
       } else if (email) {
@@ -135,11 +136,11 @@ async function pullLeadsFromNotion(userId: string, databaseId: string, accessTok
 
         if (byEmail) {
           await db.update(leadsTable)
-            .set({ notionPageId, name, status, source, isBeta, updatedAt: new Date() })
+            .set({ notionPageId, name, status, source, isBeta, notes, updatedAt: new Date() })
             .where(and(eq(leadsTable.id, byEmail.id), eq(leadsTable.userId, userId)));
         } else {
           await db.insert(leadsTable).values({
-            name, email, status, source, isBeta, notionPageId, userId,
+            name, email, status, source, isBeta, notes, notionPageId, userId,
           });
         }
       }

--- a/artifacts/api-server/src/lib/notionSync.ts
+++ b/artifacts/api-server/src/lib/notionSync.ts
@@ -1,7 +1,8 @@
 import { db } from "@workspace/db";
-import { settingsTable, leadsTable, contactsTable } from "@workspace/db";
-import { eq, and } from "drizzle-orm";
+import { settingsTable, leadsTable, contactsTable, activitiesTable, leadFilesTable, filesTable } from "@workspace/db";
+import { eq, and, desc } from "drizzle-orm";
 import { getNotesProvider } from "./integrations/registry";
+import { ObjectStorageService } from "./objectStorage";
 
 async function getNotionDbIdForUser(key: string, userId: string | null): Promise<string | null> {
   if (!userId) return null;
@@ -21,6 +22,44 @@ export function fireAndForgetLeadSync(lead: any) {
   ]).then(async ([dbId, provider]) => {
     if (!dbId || !provider) return;
     try {
+      // Enrich lead with activity summary
+      const activities = await db
+        .select({ type: activitiesTable.type, subject: activitiesTable.subject, direction: activitiesTable.direction, createdAt: activitiesTable.createdAt })
+        .from(activitiesTable)
+        .where(and(eq(activitiesTable.leadId, lead.id), eq(activitiesTable.userId, lead.userId)))
+        .orderBy(desc(activitiesTable.createdAt))
+        .limit(10);
+
+      if (activities.length > 0) {
+        lead._activitySummary = activities.map((a) => {
+          const date = a.createdAt ? new Date(a.createdAt).toISOString().slice(0, 10) : "unknown";
+          const dir = a.direction ? ` (${a.direction})` : "";
+          const subj = a.subject ? ` - ${a.subject}` : "";
+          return `${date}: ${a.type}${dir}${subj}`;
+        }).join("\n").slice(0, 2000);
+      }
+
+      // Enrich lead with file URLs
+      const leadFiles = await db
+        .select({ name: filesTable.name, storageKey: filesTable.storageKey })
+        .from(leadFilesTable)
+        .innerJoin(filesTable, eq(leadFilesTable.fileId, filesTable.id))
+        .where(eq(leadFilesTable.leadId, lead.id));
+
+      if (leadFiles.length > 0) {
+        const storage = new ObjectStorageService();
+        const fileUrls: { name: string; url: string }[] = [];
+        for (const f of leadFiles) {
+          try {
+            const url = await storage.getSignedDownloadUrl(`/objects/${f.storageKey}`, 604800);
+            fileUrls.push({ name: f.name, url });
+          } catch {
+            // Skip files that can't be signed (e.g. missing from storage)
+          }
+        }
+        if (fileUrls.length > 0) lead._fileUrls = fileUrls;
+      }
+
       const pageId = await provider.syncLead(lead, dbId);
       if (pageId && !lead.notionPageId) {
         await db.update(leadsTable).set({ notionPageId: pageId }).where(eq(leadsTable.id, lead.id));


### PR DESCRIPTION
- Notes: two-way sync via rich_text (pulls from Notion, pushes from CRM)
- Activity: one-way push summarizing last 10 activities as text
- Files: one-way push of signed S3 download URLs as external file links

https://claude.ai/code/session_01V6EdwzyqSocLTTM42p9ko7